### PR TITLE
Make compatible with sdcc 3.9.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ SDCC_PREFIX ?=
 
 CC = $(SDCC_PREFIX)sdcc
 AS = $(SDCC_PREFIX)sdas8051
-AR = $(SDCC_PREFIX)sdcclib
+AR = $(SDCC_PREFIX)sdar
 PACKIHX=$(SDCC_PREFIX)packihx
 
 CFLAGS+=-mmcs51 --no-xinit-opt -I${LIBDIR}

--- a/fx2/Makefile
+++ b/fx2/Makefile
@@ -19,11 +19,11 @@ CC=sdcc
 CFLAGS+=-mmcs51 --no-xinit-opt -I.
 CPPFLAGS+=
 OBJS=delay.rel fx2utils.rel i2c.rel isr.rel timer.rel usb_common.rel
-AR=sdcclib
+AR=sdar
 
 (%.rel) : %.c
 	$(CC) $(CFLAGS) $(CPPFLAGS) -c $< -o $*.rel
-	$(AR) -a $@ $*.rel
+	$(AR) -rc $@ $*.rel
 	rm $*.rel
 
 libfx2.lib: libfx2.lib($(OBJS))


### PR DESCRIPTION
sdcclib was replaced by sdar

Debian build failure bug: https://bugs.debian.org/963389