### PR TITLE
Fix build with sdcc 4.5.0; Add Xilinx Platform Cable USB II (DLC10) Internal Chain Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ SHELL := /bin/bash
 
 # Specify a list of targets to build. Each target requires a hw_$target.c file
 # to be present, and will produce a usbjtag-$target.hex output file.
-TARGETS=basic dj_usb saxo_l xpcu_i xpcu_x nexys opsis nanodla
+TARGETS=basic dj_usb saxo_l xpcu_i xpcu_x xpcu2_i nexys opsis nanodla
 
 HEX_OUTPUTS=$(TARGETS:%=usbjtag-%.hex)
 

--- a/fx2/fx2regs.h
+++ b/fx2/fx2regs.h
@@ -330,66 +330,66 @@ sfr at 0x84 DPL1;
 sfr at 0x85 DPH1;
 sfr at 0x86 DPS;
          /*  DPS  */
-         sbit at 0x86+0 SEL;
+         sbit at (0x86+0) SEL;
 sfr at 0x87 PCON;   /*  PCON  */
-         //sbit IDLE   = 0x87+0;
-         //sbit STOP   = 0x87+1;
-         //sbit GF0    = 0x87+2;
-         //sbit GF1    = 0x87+3;
-         //sbit SMOD0  = 0x87+7;
+         //sbit IDLE   = (0x87+0);
+         //sbit STOP   = (0x87+1);
+         //sbit GF0    = (0x87+2);
+         //sbit GF1    = (0x87+3);
+         //sbit SMOD0  = (0x87+7);
 sfr at 0x88 TCON;
          /*  TCON  */
-         sbit at 0x88+0 IT0;
-         sbit at 0x88+1 IE0;
-         sbit at 0x88+2 IT1;
-         sbit at 0x88+3 IE1;
-         sbit at 0x88+4 TR0;
-         sbit at 0x88+5 TF0;
-         sbit at 0x88+6 TR1;
-         sbit at 0x88+7 TF1;
+         sbit at (0x88+0) IT0;
+         sbit at (0x88+1) IE0;
+         sbit at (0x88+2) IT1;
+         sbit at (0x88+3) IE1;
+         sbit at (0x88+4) TR0;
+         sbit at (0x88+5) TF0;
+         sbit at (0x88+6) TR1;
+         sbit at (0x88+7) TF1;
 sfr at 0x89 TMOD;
          /*  TMOD  */
-         //sbit M00    = 0x89+0;
-         //sbit M10    = 0x89+1;
-         //sbit CT0    = 0x89+2;
-         //sbit GATE0  = 0x89+3;
-         //sbit M01    = 0x89+4;
-         //sbit M11    = 0x89+5;
-         //sbit CT1    = 0x89+6;
-         //sbit GATE1  = 0x89+7;
+         //sbit M00    = (0x89+0);
+         //sbit M10    = (0x89+1);
+         //sbit CT0    = (0x89+2);
+         //sbit GATE0  = (0x89+3);
+         //sbit M01    = (0x89+4);
+         //sbit M11    = (0x89+5);
+         //sbit CT1    = (0x89+6);
+         //sbit GATE1  = (0x89+7);
 sfr at 0x8A TL0;
 sfr at 0x8B TL1;
 sfr at 0x8C TH0;
 sfr at 0x8D TH1;
 sfr at 0x8E CKCON;
          /*  CKCON  */
-         //sbit MD0    = 0x89+0;
-         //sbit MD1    = 0x89+1;
-         //sbit MD2    = 0x89+2;
-         //sbit T0M    = 0x89+3;
-         //sbit T1M    = 0x89+4;
-         //sbit T2M    = 0x89+5;
+         //sbit MD0    = (0x89+0);
+         //sbit MD1    = (0x89+1);
+         //sbit MD2    = (0x89+2);
+         //sbit T0M    = (0x89+3);
+         //sbit T1M    = (0x89+4);
+         //sbit T2M    = (0x89+5);
 // sfr at 0x8F SPC_FNC; // Was WRS in Reg320
          /*  CKCON  */
          //sbit WRS    = 0x8F+0;
 sfr at 0x90 IOB;
 sfr at 0x91 EXIF; // EXIF Bit Values differ from Reg320
          /*  EXIF  */
-         //sbit USBINT = 0x91+4;
-         //sbit I2CINT = 0x91+5;
-         //sbit IE4    = 0x91+6;
-         //sbit IE5    = 0x91+7;
+         //sbit USBINT = (0x91+4);
+         //sbit I2CINT = (0x91+5);
+         //sbit IE4    = (0x91+6);
+         //sbit IE5    = (0x91+7);
 sfr at 0x92 MPAGE;
 sfr at 0x98 SCON0;
          /*  SCON0  */
-         sbit at 0x98+0 RI;
-         sbit at 0x98+1 TI;
-         sbit at 0x98+2 RB8;
-         sbit at 0x98+3 TB8;
-         sbit at 0x98+4 REN;
-         sbit at 0x98+5 SM2;
-         sbit at 0x98+6 SM1;
-         sbit at 0x98+7 SM0;
+         sbit at (0x98+0) RI;
+         sbit at (0x98+1) TI;
+         sbit at (0x98+2) RB8;
+         sbit at (0x98+3) TB8;
+         sbit at (0x98+4) REN;
+         sbit at (0x98+5) SM2;
+         sbit at (0x98+6) SM1;
+         sbit at (0x98+7) SM0;
 sfr at 0x99 SBUF0;
 
 sfr at 0x9A APTR1H;
@@ -407,33 +407,33 @@ sfr at 0xA2 INT4CLR;
 
 sfr at 0xA8 IE;
          /*  IE  */
-         sbit at 0xA8+0 EX0;
-         sbit at 0xA8+1 ET0;
-         sbit at 0xA8+2 EX1;
-         sbit at 0xA8+3 ET1;
-         sbit at 0xA8+4 ES0;
-         sbit at 0xA8+5 ET2;
-         sbit at 0xA8+6 ES1;
-         sbit at 0xA8+7 EA;
+         sbit at (0xA8+0) EX0;
+         sbit at (0xA8+1) ET0;
+         sbit at (0xA8+2) EX1;
+         sbit at (0xA8+3) ET1;
+         sbit at (0xA8+4) ES0;
+         sbit at (0xA8+5) ET2;
+         sbit at (0xA8+6) ES1;
+         sbit at (0xA8+7) EA;
 
 sfr at 0xAA EP2468STAT;
          /* EP2468STAT */
-         //sbit EP2E   = 0xAA+0;
-         //sbit EP2F   = 0xAA+1;
-         //sbit EP4E   = 0xAA+2;
-         //sbit EP4F   = 0xAA+3;
-         //sbit EP6E   = 0xAA+4;
-         //sbit EP6F   = 0xAA+5;
-         //sbit EP8E   = 0xAA+6;
-         //sbit EP8F   = 0xAA+7;
+         //sbit EP2E   = (0xAA+0);
+         //sbit EP2F   = (0xAA+1);
+         //sbit EP4E   = (0xAA+2);
+         //sbit EP4F   = (0xAA+3);
+         //sbit EP6E   = (0xAA+4);
+         //sbit EP6F   = (0xAA+5);
+         //sbit EP8E   = (0xAA+6);
+         //sbit EP8F   = (0xAA+7);
 
 sfr at 0xAB EP24FIFOFLGS;
 sfr at 0xAC EP68FIFOFLGS;
 sfr at 0xAF AUTOPTRSETUP;
             /* AUTOPTRSETUP */
-            sbit at 0xAF+0 EXTACC;
-            sbit at 0xAF+1 APTR1FZ;
-            sbit at 0xAF+2 APTR2FZ;
+            sbit at (0xAF+0) EXTACC;
+            sbit at (0xAF+1) APTR1FZ;
+            sbit at (0xAF+2) APTR2FZ;
 
 sfr at 0xB0 IOD;
 sfr at 0xB1 IOE;
@@ -445,13 +445,13 @@ sfr at 0xB6 OEE;
 
 sfr at 0xB8 IP;
          /*  IP  */
-         sbit at 0xB8+0 PX0;
-         sbit at 0xB8+1 PT0;
-         sbit at 0xB8+2 PX1;
-         sbit at 0xB8+3 PT1;
-         sbit at 0xB8+4 PS0;
-         sbit at 0xB8+5 PT2;
-         sbit at 0xB8+6 PS1;
+         sbit at (0xB8+0) PX0;
+         sbit at (0xB8+1) PT0;
+         sbit at (0xB8+2) PX1;
+         sbit at (0xB8+3) PT1;
+         sbit at (0xB8+4) PS0;
+         sbit at (0xB8+5) PT2;
+         sbit at (0xB8+6) PS1;
 
 sfr at 0xBA EP01STAT;
 sfr at 0xBB GPIFTRIG;
@@ -462,61 +462,61 @@ sfr at 0xBF GPIFSGLDATLNOX;
 
 sfr at 0xC0 SCON1;
          /*  SCON1  */
-         sbit at 0xC0+0 RI1;
-         sbit at 0xC0+1 TI1;
-         sbit at 0xC0+2 RB81;
-         sbit at 0xC0+3 TB81;
-         sbit at 0xC0+4 REN1;
-         sbit at 0xC0+5 SM21;
-         sbit at 0xC0+6 SM11;
-         sbit at 0xC0+7 SM01;
+         sbit at (0xC0+0) RI1;
+         sbit at (0xC0+1) TI1;
+         sbit at (0xC0+2) RB81;
+         sbit at (0xC0+3) TB81;
+         sbit at (0xC0+4) REN1;
+         sbit at (0xC0+5) SM21;
+         sbit at (0xC0+6) SM11;
+         sbit at (0xC0+7) SM01;
 sfr at 0xC1 SBUF1;
 sfr at 0xC8 T2CON;
          /*  T2CON  */
-	 sbit at 0xC8+0 CP_RL2;
-	 sbit at 0xC8+1 C_T2;
-         sbit at 0xC8+2 TR2;
-         sbit at 0xC8+3 EXEN2;
-         sbit at 0xC8+4 TCLK;
-         sbit at 0xC8+5 RCLK;
-         sbit at 0xC8+6 EXF2;
-         sbit at 0xC8+7 TF2;
+	 sbit at (0xC8+0) CP_RL2;
+	 sbit at (0xC8+1) C_T2;
+         sbit at (0xC8+2) TR2;
+         sbit at (0xC8+3) EXEN2;
+         sbit at (0xC8+4) TCLK;
+         sbit at (0xC8+5) RCLK;
+         sbit at (0xC8+6) EXF2;
+         sbit at (0xC8+7) TF2;
 sfr at 0xCA RCAP2L;
 sfr at 0xCB RCAP2H;
 sfr at 0xCC TL2;
 sfr at 0xCD TH2;
 sfr at 0xD0 PSW;
          /*  PSW  */
-         sbit at 0xD0+0 P;
-         sbit at 0xD0+1 FL;
-         sbit at 0xD0+2 OV;
-         sbit at 0xD0+3 RS0;
-         sbit at 0xD0+4 RS1;
-         sbit at 0xD0+5 F0;
-         sbit at 0xD0+6 AC;
-         sbit at 0xD0+7 CY;
+         sbit at (0xD0+0) P;
+         sbit at (0xD0+1) FL;
+         sbit at (0xD0+2) OV;
+         sbit at (0xD0+3) RS0;
+         sbit at (0xD0+4) RS1;
+         sbit at (0xD0+5) F0;
+         sbit at (0xD0+6) AC;
+         sbit at (0xD0+7) CY;
 sfr at 0xD8 EICON; // Was WDCON in DS80C320 EICON; Bit Values differ from Reg320
          /*  EICON  */
-         sbit at 0xD8+3 INT6;
-         sbit at 0xD8+4 RESI;
-         sbit at 0xD8+5 ERESI;
-         sbit at 0xD8+7 SMOD1;
+         sbit at (0xD8+3) INT6;
+         sbit at (0xD8+4) RESI;
+         sbit at (0xD8+5) ERESI;
+         sbit at (0xD8+7) SMOD1;
 sfr at 0xE0 ACC;
 sfr at 0xE8 EIE; // EIE Bit Values differ from Reg320
                         /*  EIE  */
-         sbit at 0xE8+0 EIUSB;
-         sbit at 0xE8+1 EI2C;
-         sbit at 0xE8+2 EIEX4;
-         sbit at 0xE8+3 EIEX5;
-         sbit at 0xE8+4 EIEX6;
+         sbit at (0xE8+0) EIUSB;
+         sbit at (0xE8+1) EI2C;
+         sbit at (0xE8+2) EIEX4;
+         sbit at (0xE8+3) EIEX5;
+         sbit at (0xE8+4) EIEX6;
 sfr at 0xF0 B;
 sfr at 0xF8 EIP; // EIP Bit Values differ from Reg320
                         /*  EIP  */
-         sbit at 0xF8+0 PUSB;
-         sbit at 0xF8+1 PI2C;
-         sbit at 0xF8+2 EIPX4;
-         sbit at 0xF8+3 EIPX5;
-         sbit at 0xF8+4 EIPX6;
+         sbit at (0xF8+0) PUSB;
+         sbit at (0xF8+1) PI2C;
+         sbit at (0xF8+2) EIPX4;
+         sbit at (0xF8+3) EIPX5;
+         sbit at (0xF8+4) EIPX6;
 
 /*-----------------------------------------------------------------------------
    Bit Masks

--- a/hw_xpcu2_i.c
+++ b/hw_xpcu2_i.c
@@ -1,0 +1,184 @@
+/*-----------------------------------------------------------------------------
+ *
+ * Hardware-dependent code for usb_jtag
+ *-----------------------------------------------------------------------------
+ * Copyright (C) 2007 Kolja Waschk, ixo.de
+ *-----------------------------------------------------------------------------
+ * This code is part of usbjtag. usbjtag is free software; you can redistribute
+ * it and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the License,
+ * or (at your option) any later version. usbjtag is distributed in the hope
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.  You should have received a
+ * copy of the GNU General Public License along with this program in the file
+ * COPYING; if not, write to the Free Software Foundation, Inc., 51 Franklin
+ * St, Fifth Floor, Boston, MA  02110-1301  USA
+ *-----------------------------------------------------------------------------
+ */
+
+/*
+ * Xilinx Platform Cable II (DLC10): Access internal XC3S200A-FT256-4C FPGA
+ */
+
+#include "hardware.h"
+#include "fx2regs.h"
+#include "syncdelay.h"
+
+//---------------------------------------------------------------------------
+
+#define SetOrClear(port, mask, input) \
+  ((input) ? (port|=mask) : (port&=~mask))
+
+// PB7 -> tristate buffer -> FPGA_TCK
+#define bmTCK bmBIT7 // Output
+#define SetTCK(x)     SetOrClear(IOB, bmTCK, x)
+
+// PB4 -> FPGA_TMS
+#define bmTMS bmBIT4 // Output
+#define SetTMS(x)     SetOrClear(IOB, bmTMS, x)
+
+// PB0 -> FPGA_TDI
+#define bmTDI bmBIT0 // Output - Data from FX2 into FPGA
+#define SetTDI(x)     SetOrClear(IOB, bmTDI, x)
+
+// PC6 <- FPGA_TDO
+#define bmTDO bmBIT6 // Input - Data from FPGA into FX2
+#define bitTDO 6
+
+#define GetTDO()      GetTDOToBit(0)
+#define GetTDOToBit(bitPos) \
+ (((int)(bitTDO-bitPos) > (int)0) ? \
+   ((IOC & bmTDO)>>(bitTDO-bitPos)) : \
+   ((IOC & bmTDO)<<(bitPos-bitTDO)) ) \
+
+// CTL2 -> active-high output enable for FPGA_TCK
+#define bmTCK_OE bmBIT2
+
+// PC7 -> MAX6412 active-low Manual Reset (MR) -> FPGA_PROG_B
+#define bmFPGA_RESET bmBIT7
+
+// PE6 -> active-high FPGA power enable
+#define bmFPGA_POWER bmBIT6
+
+/* XPCU2 has neither AS nor PS mode pins */
+
+//-----------------------------------------------------------------------------
+
+void ProgIO_Poll(void)    {}
+void ProgIO_Enable(void)  {}
+void ProgIO_Disable(void) {}
+void ProgIO_Deinit(void)  {}
+
+void ProgIO_Init(void)
+{
+  /* The following code depends on your actual circuit design.
+     Make required changes _before_ you try the code! */
+
+  // set the CPU clock to 48MHz, enable clock output to FPGA
+  CPUCS = bmCLKOE | bmCLKSPD1;
+
+  // Use internal 48 MHz, enable output, use "Port" mode for all pins
+  IFCONFIG = bmIFCLKSRC | bm3048MHZ | bmIFCLKOE;
+
+  GPIFCTLCFG = 0x00;
+  GPIFIDLECTL = bmTCK_OE;
+  GPIFABORT = 0xFF;
+
+  PORTACFG = 0x00; OEA = 0x00; IOA = 0x00;
+  OEB = bmTCK | bmTMS | bmTDI; IOB = 0x00;
+  PORTCCFG = 0x00; OEC = bmFPGA_RESET; IOC = bmFPGA_RESET;
+  OED = 0x00;
+  PORTECFG = 0x00; OEE = bmFPGA_POWER; IOE = bmFPGA_POWER;
+}
+
+void ProgIO_Set_State(unsigned char d)
+{
+  /* Set state of output pins
+   * (d is the byte from the host):
+   *
+   * d.0 => TCK
+   * d.1 => TMS
+   * d.2 => nCE (only #ifdef HAVE_AS_MODE)
+   * d.3 => nCS (only #ifdef HAVE_AS_MODE)
+   * d.4 => TDI
+   * d.6 => LED / Output Enable
+   */
+
+  SetTCK((d & bmBIT0) ? 1 : 0);
+  SetTMS((d & bmBIT1) ? 1 : 0);
+  SetTDI((d & bmBIT4) ? 1 : 0);
+#ifdef HAVE_OE_LED
+  SetOELED((d & bmBIT5) ? 1 : 0);
+#endif
+}
+
+unsigned char ProgIO_Set_Get_State(unsigned char d)
+{
+  /* Set state of output pins (s.a.)
+   * then read state of input pins:
+   *
+   * TDO => d.0
+   * DATAOUT => d.1 (only #ifdef HAVE_AS_MODE)
+   */
+
+  ProgIO_Set_State(d);
+  return 2|GetTDO(); /* DATAOUT assumed high, no AS mode */
+}
+
+void ProgIO_ShiftOut(unsigned char c)
+{
+  /* Shift out byte C:
+   *
+   * 8x {
+   *   Output least significant bit on TDI
+   *   Raise TCK
+   *   Shift c right
+   *   Lower TCK
+   * }
+   */
+
+  unsigned char lc=c;
+
+  SetTDI(lc & bmBIT0); SetTCK(1); lc>>=1; SetTCK(0);
+  SetTDI(lc & bmBIT0); SetTCK(1); lc>>=1; SetTCK(0);
+  SetTDI(lc & bmBIT0); SetTCK(1); lc>>=1; SetTCK(0);
+  SetTDI(lc & bmBIT0); SetTCK(1); lc>>=1; SetTCK(0);
+
+  SetTDI(lc & bmBIT0); SetTCK(1); lc>>=1; SetTCK(0);
+  SetTDI(lc & bmBIT0); SetTCK(1); lc>>=1; SetTCK(0);
+  SetTDI(lc & bmBIT0); SetTCK(1); lc>>=1; SetTCK(0);
+  SetTDI(lc & bmBIT0); SetTCK(1); lc>>=1; SetTCK(0);
+}
+
+unsigned char ProgIO_ShiftInOut(unsigned char c)
+{
+  /* Shift out byte C, shift in from TDO:
+   *
+   * 8x {
+   *   Read carry from TDO
+   *   Output least significant bit on TDI
+   *   Raise TCK
+   *   Shift c right, append carry (TDO) at left (into MSB)
+   *   Lower TCK
+   * }
+   * Return c.
+   */
+
+  unsigned char carry;
+  unsigned char lc=c;
+
+  carry = GetTDOToBit(7); SetTDI(lc & bmBIT0); SetTCK(1); lc=carry|(lc>>1); SetTCK(0); 
+  carry = GetTDOToBit(7); SetTDI(lc & bmBIT0); SetTCK(1); lc=carry|(lc>>1); SetTCK(0);
+  carry = GetTDOToBit(7); SetTDI(lc & bmBIT0); SetTCK(1); lc=carry|(lc>>1); SetTCK(0);
+  carry = GetTDOToBit(7); SetTDI(lc & bmBIT0); SetTCK(1); lc=carry|(lc>>1); SetTCK(0);
+
+  carry = GetTDOToBit(7); SetTDI(lc & bmBIT0); SetTCK(1); lc=carry|(lc>>1); SetTCK(0);
+  carry = GetTDOToBit(7); SetTDI(lc & bmBIT0); SetTCK(1); lc=carry|(lc>>1); SetTCK(0);
+  carry = GetTDOToBit(7); SetTDI(lc & bmBIT0); SetTCK(1); lc=carry|(lc>>1); SetTCK(0);
+  carry = GetTDOToBit(7); SetTDI(lc & bmBIT0); SetTCK(1); lc=carry|(lc>>1); SetTCK(0);
+
+  return lc;
+}
+
+

--- a/hw_xpcu_i.c
+++ b/hw_xpcu_i.c
@@ -54,7 +54,7 @@
 
 #define HAVE_OE_LED 1
 /* +0=green led, +1=red led */
-sbit at 0x80+1        OELED;
+sbit at (0x80+1)      OELED;
 #define SetOELED(x)   do{OELED=(x);}while(0)
 
 #define JTAG_PORT_OE bmTCK|bmTMS|bmTDI


### PR DESCRIPTION
This adds support to access the internal Spartan-3A FPGA of the DLC10 cable.

This has been tested with openocd (0.12.0) to load a custom bitstream (https://github.com/hansemro/xpc_dlc10_experiments/tree/blinky/gateware/blinky):

```
# Prerequisite: build and load usbjtag-xpcu2_i.hex to DLC10
fx2tool -d 03fd:0013 load usbjtag-xpcu2_i.hex

# clone and build blinky bitstream (requires Xilinx ISE)
git clone https://github.com/hansemro/xpc_dlc10_experiments -b blinky
cd xpc_dlc10_experiments/gateware/blinky
# load ISE environment
source /opt/Xilinx/14.7/ISE_DS/settings64.sh
# build blinky.bit
make

# program internal FPGA using openocd:
openocd -c 'adapter driver usb_blaster' \
        -c 'usb_blaster vid_pid 0x16c0 0x06ad 0x03fd 0x0013' \
        -c 'usb_blaster lowlevel_driver ftdi' \
        -c 'jtag newtap xc3s tap -irlen 6 -ignore-version -expected-id 0x02218093' \
        -c 'pld device virtex2 xc3s.tap' \
        -c 'init' \
        -c 'pld load 0 blinky.bit' \
        -c 'shutdown'
```

This does NOT provide access to external JTAG targets or XCF02S configuration memory (interestingly, XFC02S's JTAG interface is managed by FPGA IO pins).